### PR TITLE
feat(aurora-sweep): Add thumb-key tap dances for agrski keymap

### DIFF
--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -17,8 +17,7 @@
 #include QMK_KEYBOARD_H
 
 /*
- * Tap dances for:
- * - thumb keys to use alternate thumbs' keys.
+ * TODO - add tap dances for:
  * - function keys to switch layer instead of toggling while held; useful for debugging and search, for example; exiting layer should only require single tap.
  */
 

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -257,8 +257,59 @@ void thumb_l_inner_reset(tap_dance_state_t *state, void *user_data) {
     }
 }
 
+static td_tap_t td_state_thumb_l_outer = {
+    .is_press_action = true,
+    .state = TD_NONE
+};
+
+void thumb_l_outer_finished(tap_dance_state_t *state, void *user_date) {
+    td_state_thumb_l_outer.state = current_td_state(state);
+
+    switch (td_state_thumb_l_outer.state) {
+        case TD_TAP:
+            register_code(KC_SPC);
+            break;
+        case TD_HOLD:
+            register_mods(MOD_BIT(KC_LSFT));
+            break;
+        case TD_TAP_TAP:
+            tap_code(KC_SPC);
+            register_code(KC_SPC);
+            break;
+        case TD_TAP_HOLD:
+            register_mods(MOD_BIT(KC_LCTL));
+            break;
+        case TD_TAP_TAP_TAP:
+            tap_code(KC_SPC);
+            tap_code(KC_SPC);
+            register_code(KC_SPC);
+            break;
+        default:
+            break;
+    }
+}
+
+void thumb_l_outer_reset(tap_dance_state_t *state, void *user_data) {
+    switch (td_state_thumb_l_outer.state) {
+        case TD_TAP:
+        case TD_TAP_TAP:
+        case TD_TAP_TAP_TAP:
+            unregister_code(KC_SPC);
+            break;
+        case TD_HOLD:
+            unregister_mods(MOD_BIT(KC_LSFT));
+            break;
+        case TD_TAP_HOLD:
+            unregister_mods(MOD_BIT(KC_LCTL));
+            break;
+        default:
+            break;
+    }
+}
+
 tap_dance_action_t tap_dance_actions[] = {
-    [THUMB_L_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_inner_finished, thumb_l_inner_reset)
+    [THUMB_L_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_inner_finished, thumb_l_inner_reset),
+    [THUMB_L_OUTER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_outer_finished, thumb_l_outer_reset)
 }
 
 // END tap-dance implementation

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -207,4 +207,58 @@ td_state_t current_td_state(tap_dance_state_t *state) {
     return TD_UNKNOWN;
 }
 
+static td_tap_t td_state_thumb_l_inner = {
+    .is_press_action = true,
+    .state = TD_NONE
+};
+
+void thumb_l_inner_finished(tap_dance_state_t *state, void *user_date) {
+    td_state_thumb_l_inner.state = current_td_state(state);
+
+    switch (td_state_thumb_l_inner.state) {
+        case TD_TAP:
+            register_code(KC_BSPC);
+            break;
+        case TD_HOLD:
+            register_mods(MOD_BIT(KC_LCMD));
+            break;
+        case TD_TAP_TAP:
+            tap_code(KC_BSPC);
+            register_code(KC_BSPC);
+            break;
+        case TD_TAP_HOLD:
+            register_mods(MOD_BIT(KC_LALT));
+            break;
+        case TD_TAP_TAP_TAP:
+            tap_code(KC_BSPC);
+            tap_code(KC_BSPC);
+            register_code(KC_BSPC);
+            break;
+        default:
+            break;
+    }
+}
+
+void thumb_l_inner_reset(tap_dance_state_t *state, void *user_data) {
+    switch (td_state_thumb_l_inner.state) {
+        case TD_TAP:
+        case TD_TAP_TAP:
+        case TD_TAP_TAP_TAP:
+            unregister_code(KC_BSPC);
+            break;
+        case TD_HOLD:
+            unregister_mods(MOD_BIT(KC_LCMD));
+            break;
+        case TD_TAP_HOLD:
+            unregister_mods(MOD_BIT(KC_LALT));
+            break;
+        default:
+            break;
+    }
+}
+
+tap_dance_action_t tap_dance_actions[] = {
+    [THUMB_L_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_inner_finished, thumb_l_inner_reset)
+}
+
 // END tap-dance implementation

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -16,11 +16,6 @@
 
 #include QMK_KEYBOARD_H
 
-/*
- * TODO - add tap dances for:
- * - function keys to switch layer instead of toggling while held; useful for debugging and search, for example; exiting layer should only require single tap.
- */
-
 // BEGIN tap-dance config
 typedef enum {
     TD_NONE,

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -307,9 +307,60 @@ void thumb_l_outer_reset(tap_dance_state_t *state, void *user_data) {
     }
 }
 
+static td_tap_t td_state_thumb_r_inner = {
+    .is_press_action = true,
+    .state = TD_NONE
+};
+
+void thumb_r_inner_finished(tap_dance_state_t *state, void *user_date) {
+    td_state_thumb_r_inner.state = current_td_state(state);
+
+    switch (td_state_thumb_r_inner.state) {
+        case TD_TAP:
+            register_code(KC_ESC);
+            break;
+        case TD_HOLD:
+            register_mods(MOD_BIT(KC_LALT));
+            break;
+        case TD_TAP_TAP:
+            tap_code(KC_ESC);
+            register_code(KC_ESC);
+            break;
+        case TD_TAP_HOLD:
+            register_mods(MOD_BIT(KC_LCMD));
+            break;
+        case TD_TAP_TAP_TAP:
+            tap_code(KC_ESC);
+            tap_code(KC_ESC);
+            register_code(KC_ESC);
+            break;
+        default:
+            break;
+    }
+}
+
+void thumb_r_inner_reset(tap_dance_state_t *state, void *user_data) {
+    switch (td_state_thumb_r_inner.state) {
+        case TD_TAP:
+        case TD_TAP_TAP:
+        case TD_TAP_TAP_TAP:
+            unregister_code(KC_ESC);
+            break;
+        case TD_HOLD:
+            unregister_mods(MOD_BIT(KC_LALT));
+            break;
+        case TD_TAP_HOLD:
+            unregister_mods(MOD_BIT(KC_LCMD));
+            break;
+        default:
+            break;
+    }
+}
+
 tap_dance_action_t tap_dance_actions[] = {
     [THUMB_L_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_inner_finished, thumb_l_inner_reset),
-    [THUMB_L_OUTER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_outer_finished, thumb_l_outer_reset)
+    [THUMB_L_OUTER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_outer_finished, thumb_l_outer_reset),
+    [THUMB_R_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_r_inner_finished, thumb_r_inner_reset)
 }
 
 // END tap-dance implementation

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -357,10 +357,61 @@ void thumb_r_inner_reset(tap_dance_state_t *state, void *user_data) {
     }
 }
 
+static td_tap_t td_state_thumb_r_outer = {
+    .is_press_action = true,
+    .state = TD_NONE
+};
+
+void thumb_r_outer_finished(tap_dance_state_t *state, void *user_date) {
+    td_state_thumb_r_outer.state = current_td_state(state);
+
+    switch (td_state_thumb_r_outer.state) {
+        case TD_TAP:
+            register_code(KC_ENT);
+            break;
+        case TD_HOLD:
+            register_mods(MOD_BIT(KC_LCTL));
+            break;
+        case TD_TAP_TAP:
+            tap_code(KC_ENT);
+            register_code(KC_ENT);
+            break;
+        case TD_TAP_HOLD:
+            register_mods(MOD_BIT(KC_LSFT));
+            break;
+        case TD_TAP_TAP_TAP:
+            tap_code(KC_ENT);
+            tap_code(KC_ENT);
+            register_code(KC_ENT);
+            break;
+        default:
+            break;
+    }
+}
+
+void thumb_r_outer_reset(tap_dance_state_t *state, void *user_data) {
+    switch (td_state_thumb_r_outer.state) {
+        case TD_TAP:
+        case TD_TAP_TAP:
+        case TD_TAP_TAP_TAP:
+            unregister_code(KC_ENT);
+            break;
+        case TD_HOLD:
+            unregister_mods(MOD_BIT(KC_LCTL));
+            break;
+        case TD_TAP_HOLD:
+            unregister_mods(MOD_BIT(KC_LSFT));
+            break;
+        default:
+            break;
+    }
+}
+
 tap_dance_action_t tap_dance_actions[] = {
     [THUMB_L_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_inner_finished, thumb_l_inner_reset),
     [THUMB_L_OUTER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_outer_finished, thumb_l_outer_reset),
-    [THUMB_R_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_r_inner_finished, thumb_r_inner_reset)
+    [THUMB_R_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_r_inner_finished, thumb_r_inner_reset),
+    [THUMB_R_OUTER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_r_outer_finished, thumb_r_outer_reset)
 }
 
 // END tap-dance implementation

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -182,3 +182,29 @@ bool rgb_matrix_indicators_user(void) {
 
     return false;
 }
+
+// BEGIN tap-dance implementation
+
+td_state_t current_td_state(tap_dance_state_t *state) {
+    // Interruptions do not change the interpretation.
+    if (1 == state->count) {
+        if (!state->pressed) {
+            return TD_TAP;
+        } else {
+            return TD_HOLD;
+        }
+    } else if (2 == state->count) {
+        if (!state->pressed) {
+            return TD_TAP_TAP;
+        } else {
+            return TD_TAP_HOLD;
+        }
+    } else if (3 == state->count) {
+        // Must be fast typing; not expected to be used for held keys.
+        return TD_TAP_TAP_TAP;
+    }
+
+    return TD_UNKNOWN;
+}
+
+// END tap-dance implementation

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -411,6 +411,6 @@ tap_dance_action_t tap_dance_actions[] = {
     [THUMB_L_OUTER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_l_outer_finished, thumb_l_outer_reset),
     [THUMB_R_INNER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_r_inner_finished, thumb_r_inner_reset),
     [THUMB_R_OUTER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, thumb_r_outer_finished, thumb_r_outer_reset)
-}
+};
 
 // END tap-dance implementation

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -16,6 +16,48 @@
 
 #include QMK_KEYBOARD_H
 
+/*
+ * Tap dances for:
+ * - thumb keys to use alternate thumbs' keys.
+ * - function keys to switch layer instead of toggling while held; useful for debugging and search, for example; exiting layer should only require single tap.
+ */
+
+// BEGIN tap-dance config
+typedef enum {
+    TD_NONE,
+    TD_UNKNOWN,
+    TD_TAP,
+    TD_HOLD,
+    TD_TAP_TAP,
+    TD_TAP_HOLD,
+    TD_TAP_TAP_TAP
+} td_state_t;
+
+typedef struct {
+    bool is_press_action;
+    td_state_t state;
+} td_tap_t;
+
+enum td_sequences {
+    THUMB_L_INNER,
+    THUMB_L_OUTER,
+    THUMB_R_INNER,
+    THUMB_R_OUTER
+};
+
+td_state_t current_td_state(tap_dance_state_t *state);
+
+void thumb_l_inner_finished(tap_dance_state_t *state, void *user_date);
+void thumb_l_inner_reset(tap_dance_state_t *state, void *user_date);
+void thumb_l_outer_finished(tap_dance_state_t *state, void *user_date);
+void thumb_l_outer_reset(tap_dance_state_t *state, void *user_date);
+void thumb_r_inner_finished(tap_dance_state_t *state, void *user_date);
+void thumb_r_inner_reset(tap_dance_state_t *state, void *user_date);
+void thumb_r_outer_finished(tap_dance_state_t *state, void *user_date);
+void thumb_r_outer_reset(tap_dance_state_t *state, void *user_date);
+
+// END tap-dance config
+
 enum layer_names {
     _BASE,  // Alphabetic
     _NUM,   // Numeric

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/keymap.c
@@ -71,10 +71,10 @@ enum layer_names {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_BASE] = LAYOUT(
-        KC_P,           KC_W,           KC_F,           KC_H,           XXXXXXX,                    XXXXXXX,            KC_J,               KC_K,               KC_L,           KC_DEL,
-        LT(_FUNL, KC_A),LT(_NUM, KC_S), LT(_MSE, KC_E), LT(_I3, KC_T),  KC_G,                       KC_D,               LT(_KITTY, KC_O),   LT(_NAV, KC_I),   LT(_SYM, KC_N), LT(_FUNR, KC_Y),
-        KC_X,           KC_Q,           KC_U,           KC_R,           KC_TAB,                     KC_V,               KC_M,               KC_C,               KC_B,           KC_Z,
-                                                        CMD_T(KC_BSPC), SFT_T(KC_SPC),              CTL_T(KC_ENT),      ALT_T(KC_ESC)
+        KC_P,           KC_W,           KC_F,           KC_H,               XXXXXXX,                    XXXXXXX,            KC_J,               KC_K,               KC_L,           KC_DEL,
+        LT(_FUNL, KC_A),LT(_NUM, KC_S), LT(_MSE, KC_E), LT(_I3, KC_T),      KC_G,                       KC_D,               LT(_KITTY, KC_O),   LT(_NAV, KC_I),   LT(_SYM, KC_N), LT(_FUNR, KC_Y),
+        KC_X,           KC_Q,           KC_U,           KC_R,               KC_TAB,                     KC_V,               KC_M,               KC_C,               KC_B,           KC_Z,
+                                                        TD(THUMB_L_INNER),  TD(THUMB_L_OUTER),          TD(THUMB_R_OUTER),  TD(THUMB_R_INNER)
     ),
 
     [_NUM] = LAYOUT(

--- a/keyboards/splitkb/aurora/sweep/keymaps/agrski/rules.mk
+++ b/keyboards/splitkb/aurora/sweep/keymaps/agrski/rules.mk
@@ -1,5 +1,6 @@
 CONVERT_TO = liatris
 
+TAP_DANCE_ENABLE    = yes
 LTO_ENABLE          = yes
 MOUSEKEY_ENABLE     = yes
 EXTRAKEY_ENABLE     = yes


### PR DESCRIPTION
## Description
All changes apply to `-kb splitkb/aurora/sweep/ -km agrski`:
* Enable use of tap dance functionality.
* Add tap-hold tap dances on left & right thumb keys for alternate thumb's mods.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
N/A

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
